### PR TITLE
setup(ci): set Dependabot PR prefixes to match pr-name-validator convention

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,13 +5,19 @@ updates:
       directory: "/"
       schedule:
           interval: "daily"
+      commit-message:
+          prefix: "setup(ci)"
 
     - package-ecosystem: "docker"
       directory: "/"
       schedule:
           interval: "daily"
+      commit-message:
+          prefix: "setup(dockerfile)"
 
     - package-ecosystem: "gomod"
       directory: "/"
       schedule:
           interval: "daily"
+      commit-message:
+          prefix: "setup(go)"


### PR DESCRIPTION
## Summary

Configures Dependabot to emit PR titles that follow the [pr-name-validator](https://github.com/Articola-Tools/pr-name-validator) convention. Without this, Dependabot uses its built-in defaults (`deps(github-actions):`, `deps(build):`, `deps(go):`) which fail the PR name lint check.

## Changes

Per `updates` entry, add `commit-message.prefix`:

| Ecosystem        | Before (default)     | After             |
|------------------|----------------------|-------------------|
| `github-actions` | `deps(github-actions):` | `setup(ci):`   |
| `docker`         | `deps(build):`       | `setup(dockerfile):` |
| `gomod`          | `deps(go):`          | `setup(go):`      |

`setup` is the correct type from pr-name-validator's convention ("Configuration of repository/tools/assets/resources").

## Notes

- This PR itself uses `setup(ci):` to pass the pr-name-validator lint.
- The previous commit message used `chore(ci):` which isn't a valid type; the PR title is what pr-name-validator actually checks.